### PR TITLE
添加微博信息

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -26,6 +26,7 @@ slug: /
 - [Twitch](https://www.twitch.tv/hecatiaz)
 - [Patreon](https://www.patreon.com/Hecatia)
 - [Pixiv](https://www.pixiv.net/users/66875796)
+- [Weibo](https://weibo.com/u/7363797389)
 
 ### 尼比鲁研究中心
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -62,6 +62,10 @@ module.exports = {
               label: "Pixiv",
               href: "https://www.pixiv.net/artworks/90288006",
             },
+            {
+              lable: "Weibo",
+              href: "https://weibo.com/u/7363797389",
+            },
           ],
         },
         {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -63,7 +63,7 @@ module.exports = {
               href: "https://www.pixiv.net/artworks/90288006",
             },
             {
-              lable: "Weibo",
+              label: "Weibo",
               href: "https://weibo.com/u/7363797389",
             },
           ],

--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -31,6 +31,10 @@
     "message": "Pixiv",
     "description": "The label of footer link with label=Pixiv linking to https://www.pixiv.net/artworks/90288006"
   },
+  "link.item.label.Weibo": {
+    "message": "Weibo",
+    "description": "The label of footer link with label=Weibo linking to https://weibo.com/u/7363797389"
+  },
   "link.item.label.Discord (English)": {
     "message": "Discord (English)",
     "description": "The label of footer link with label=Discord (English) linking to https://discord.gg/hecatia"


### PR DESCRIPTION
根据[赫卡 Tia 的动态](https://t.bilibili.com/547030317844712233)，B 站动态停止更新日常内容

```yaml
--- #赫卡 Tia 的动态
url: https://t.bilibili.com/547030317844712233
datetime: 2021-07-13T19:17:01Z
content: |
  🪐重新发一下公告吧，
  赫卡的水动态的动态一般都只会在微博了，
  b站只会发联动、视频、直播动态，
  原因是因为，很多水的动态会把公告、视频的动态埋掉，包括转发的fanart，也会被埋掉，大家就看不到这些优秀和重要的东西了。
  自己生活上的事情都是些无关紧要的小事，但是跟重要的东西一起发就会更吸引人注意，变得很重要一样，事实上只是些无聊的水水水。
  所以做出了这个决定，希望大家尊重，谢谢！
...
```